### PR TITLE
Add examples for Relations and UUIDs using newly supported Widgets

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -20,6 +20,13 @@ parts =
 
 develop = .
 
+auto-checkout =
+    plone.app.z3cform
+    plone.app.vocabularies
+
+[sources]
+plone.app.z3cform = git https://github.com/plone/plone.app.z3cform.git pushurl=git@github.com:plone/plone.app.z3cform.git rev=62080da
+plone.app.vocabularies = git https://github.com/plone/plone.app.vocabularies.git pushurl=git@github.com:plone/plone.app.vocabularies.git rev=4569295
 
 [instance]
 recipe = plone.recipe.zope2instance

--- a/src/example/contenttype/configure.zcml
+++ b/src/example/contenttype/configure.zcml
@@ -28,4 +28,8 @@
       name="example.contenttype-hiddenprofiles"
       />
 
+  <utility
+      name="example.vocabularies.documents"
+      component="example.contenttype.vocabularies.DocumentVocabularyFactory" />
+
 </configure>

--- a/src/example/contenttype/example.py
+++ b/src/example/contenttype/example.py
@@ -14,6 +14,7 @@ from plone.dexterity.content import Container
 from plone.namedfile.field import NamedBlobFile
 from plone.namedfile.field import NamedBlobImage
 from plone.schema import Email
+
 # from plone.schema import (
 #     Dict,
 # )  # take Dict field from plone.schema to use the widget attribute
@@ -32,23 +33,22 @@ from zope.interface import Interface
 
 
 class IMyRowSchema(Interface):
-    """Define schema for row in Plone Classic DataGridField
-    """
+    """Define schema for row in Plone Classic DataGridField"""
 
     choice_field = schema.Choice(
-        title=u'Choice Field',
-        vocabulary='plone.app.vocabularies.PortalTypes',
+        title=u"Choice Field",
+        vocabulary="plone.app.vocabularies.PortalTypes",
         required=False,
-        )
-    directives.widget('objective', SelectFieldWidget)
+    )
+    directives.widget("objective", SelectFieldWidget)
 
     textline_field = schema.TextLine(
-        title=u'Textline field',
+        title=u"Textline field",
         required=False,
-        )
+    )
 
     bool_field = schema.Bool(
-        title=u'Boolean field',
+        title=u"Boolean field",
         required=False,
     )
 
@@ -60,93 +60,93 @@ class IExample(model.Schema):
     # textline, text, bool, richtext, email
 
     fieldset(
-        'numberfields',
-        label=u'Number fields',
-        fields=('int_field', 'float_field'),
+        "numberfields",
+        label=u"Number fields",
+        fields=("int_field", "float_field"),
     )
 
     fieldset(
-        'datetimefields',
-        label=u'Date and time fields',
+        "datetimefields",
+        label=u"Date and time fields",
         fields=(
-            'datetime_field',
-            'date_field',
-            'time_field',
-            'timedelta_field',
+            "datetime_field",
+            "date_field",
+            "time_field",
+            "timedelta_field",
         ),
     )
 
     fieldset(
-        'choicefields',
-        label=u'Choice and Multiple Choice fields',
+        "choicefields",
+        label=u"Choice and Multiple Choice fields",
         fields=(
-            'choice_field',
-            'choice_field_radio',
-            'choice_field_select',
-            'choice_field_voc',
-            'list_field',
-            'list_field_checkbox',
-            'list_field_select',
-            'list_field_voc_unconstrained',
-            'tuple_field',
-            'set_field',
-            'set_field_checkbox',
+            "choice_field",
+            "choice_field_radio",
+            "choice_field_select",
+            "choice_field_voc",
+            "list_field",
+            "list_field_checkbox",
+            "list_field_select",
+            "list_field_voc_unconstrained",
+            "tuple_field",
+            "set_field",
+            "set_field_checkbox",
         ),
     )
 
     fieldset(
-        'relationfields',
-        label=u'Relation fields',
+        "relationfields",
+        label=u"Relation fields",
         fields=(
-            'relationchoice_field',
-            'relationlist_field',
-            'relationchoice_field_constrained',
-            'relationlist_field_constrained',
-            'relationlist_field_search_mode',
-            'relationchoice_field_select',
-            'relationchoice_field_radio',
-            'relationlist_field_select',
-            'relationlist_field_checkbox',
-            'relationchoice_field_ajax_select',
-            'relationlist_field_ajax_select',
+            "relationchoice_field",
+            "relationlist_field",
+            "relationchoice_field_constrained",
+            "relationlist_field_constrained",
+            "relationlist_field_search_mode",
+            "relationchoice_field_select",
+            "relationchoice_field_radio",
+            "relationlist_field_select",
+            "relationlist_field_checkbox",
+            "relationchoice_field_ajax_select",
+            "relationlist_field_ajax_select",
         ),
     )
 
     fieldset(
-        'uuidrelationfields',
-        label=u'Relation widgets with uuids',
+        "uuidrelationfields",
+        label=u"Relation widgets with uuids",
         fields=(
-            'uuid_choice_field',
-            'uuid_list_field',
-            'uuid_choice_field_constrained',
-            'uuid_list_field_constrained',
-            'uuid_list_field_search_mode',
-            'uuid_choice_field_select',
-            'uuid_choice_field_radio',
-            'uuid_list_field_select',
-            'uuid_list_field_checkbox',
-            'uuid_choice_field_ajax_select',
-            'uuid_list_field_ajax_select',
+            "uuid_choice_field",
+            "uuid_list_field",
+            "uuid_choice_field_constrained",
+            "uuid_list_field_constrained",
+            "uuid_list_field_search_mode",
+            "uuid_choice_field_select",
+            "uuid_choice_field_radio",
+            "uuid_list_field_select",
+            "uuid_list_field_checkbox",
+            "uuid_choice_field_ajax_select",
+            "uuid_list_field_ajax_select",
         ),
     )
 
     fieldset(
-        'filefields',
-        label=u'File fields',
-        fields=('file_field', 'image_field'),
+        "filefields",
+        label=u"File fields",
+        fields=("file_field", "image_field"),
     )
 
     fieldset(
         "otherfields",
         label=u"Other fields",
         fields=(
-            'uri_field',
-            'sourcetext_field',
-            'ascii_field',
-            'bytesline_field',
-            'asciiline_field',
-            'pythonidentifier_field',
-            'dottedname_field',
+            "uri_field",
+            "sourcetext_field",
+            "ascii_field",
+            "bytesline_field",
+            "asciiline_field",
+            "pythonidentifier_field",
+            "dottedname_field",
             # 'dict_field',
             # "vocabularyterms_field",
             # "vocabularytermstranslation_field",
@@ -155,11 +155,9 @@ class IExample(model.Schema):
     )
 
     fieldset(
-        'datagrid',
-        label=u'Datagrid field',
-        fields=(
-            'datagrid_field',
-            ),
+        "datagrid",
+        label=u"Datagrid field",
+        fields=("datagrid_field",),
     )
 
     primary("title")
@@ -203,333 +201,330 @@ class IExample(model.Schema):
 
     directives.widget(choice_field_radio=RadioFieldWidget)
     choice_field_radio = schema.Choice(
-        title=u'Choice field with radio boxes',
+        title=u"Choice field with radio boxes",
         description=u"zope.schema.Choice",
-        values=[u'One', u'Two', u'Three'],
+        values=[u"One", u"Two", u"Three"],
         required=False,
-        )
+    )
 
     choice_field_voc = schema.Choice(
-        title=u'Choicefield with values from named vocabulary',
+        title=u"Choicefield with values from named vocabulary",
         description=u"zope.schema.Choice",
-        vocabulary='plone.app.vocabularies.PortalTypes',
+        vocabulary="plone.app.vocabularies.PortalTypes",
         required=False,
-        )
+    )
 
     directives.widget(choice_field_select=SelectFieldWidget)
     choice_field_select = schema.Choice(
-        title=u'Choicefield with select2 widget',
+        title=u"Choicefield with select2 widget",
         description=u"zope.schema.Choice",
-        vocabulary='plone.app.vocabularies.PortalTypes',
+        vocabulary="plone.app.vocabularies.PortalTypes",
         required=False,
-        )
+    )
 
     list_field = schema.List(
-        title=u'List field',
+        title=u"List field",
         description=u"zope.schema.List",
         value_type=schema.Choice(
-            values=[u'Beginner', u'Advanced', u'Professional'],
-            ),
+            values=[u"Beginner", u"Advanced", u"Professional"],
+        ),
         required=False,
         missing_value=[],
-        )
+    )
 
     directives.widget(list_field_checkbox=CheckBoxFieldWidget)
     list_field_checkbox = schema.List(
-        title=u'List field with checkboxes',
+        title=u"List field with checkboxes",
         description=u"zope.schema.List",
         value_type=schema.Choice(
-            values=[u'Beginner', u'Advanced', u'Professional'],
-            ),
+            values=[u"Beginner", u"Advanced", u"Professional"],
+        ),
         required=False,
         missing_value=[],
-        )
+    )
 
     directives.widget(list_field_select=SelectFieldWidget)
     list_field_select = schema.List(
-        title=u'List field with select widget',
+        title=u"List field with select widget",
         description=u"zope.schema.List",
         value_type=schema.Choice(
-            values=[u'Beginner', u'Advanced', u'Professional'],
-            ),
+            values=[u"Beginner", u"Advanced", u"Professional"],
+        ),
         required=False,
         missing_value=[],
-        )
+    )
 
     list_field_voc_unconstrained = schema.List(
-        title=u'List field with values from vocabulary but not constrained to them.',
+        title=u"List field with values from vocabulary but not constrained to them.",
         description=u"zope.schema.List",
         value_type=schema.TextLine(),
         required=False,
         missing_value=[],
-        )
+    )
     directives.widget(
-        'list_field_voc_unconstrained',
+        "list_field_voc_unconstrained",
         AjaxSelectFieldWidget,
-        vocabulary='plone.app.vocabularies.PortalTypes',
+        vocabulary="plone.app.vocabularies.PortalTypes",
         pattern_options={
-            'closeOnSelect': False,  # Select2 option to leave dropdown open for multiple selection
+            "closeOnSelect": False,  # Select2 option to leave dropdown open for multiple selection
         },
     )
 
     tuple_field = schema.Tuple(
-        title=u'Tuple field',
+        title=u"Tuple field",
         description=u"zope.schema.Tuple",
         value_type=schema.Choice(
-            values=[u'Beginner', u'Advanced', u'Professional'],
-            ),
+            values=[u"Beginner", u"Advanced", u"Professional"],
+        ),
         required=False,
         missing_value=(),
-        )
+    )
 
     set_field = schema.Set(
-        title=u'Set field',
+        title=u"Set field",
         description=u"zope.schema.Set",
         value_type=schema.Choice(
-            values=[u'Beginner', u'Advanced', u'Professional'],
-            ),
+            values=[u"Beginner", u"Advanced", u"Professional"],
+        ),
         required=False,
         missing_value={},
-        )
+    )
 
     directives.widget(set_field_checkbox=CheckBoxFieldWidget)
     set_field_checkbox = schema.Set(
-        title=u'Set field with checkboxes',
+        title=u"Set field with checkboxes",
         description=u"zope.schema.Set",
         value_type=schema.Choice(
-            values=[u'Beginner', u'Advanced', u'Professional'],
-            ),
+            values=[u"Beginner", u"Advanced", u"Professional"],
+        ),
         required=False,
         missing_value={},
-        )
+    )
 
     # File fields
     image_field = NamedBlobImage(
-        title=u'Image field',
-        description=u'A upload field for images (plone.namedfile.field.NamedBlobImage)',
+        title=u"Image field",
+        description=u"A upload field for images (plone.namedfile.field.NamedBlobImage)",
         required=False,
-        )
+    )
 
     file_field = NamedBlobFile(
-        title=u'File field',
-        description=u'A upload field for files (plone.namedfile.field.NamedBlobFile)',
+        title=u"File field",
+        description=u"A upload field for files (plone.namedfile.field.NamedBlobFile)",
         required=False,
-        )
+    )
 
     # Date and Time fields
     datetime_field = schema.Datetime(
-        title=u'Datetime field',
-        description=u'Uses a date and time picker (zope.schema.Datetime)',
+        title=u"Datetime field",
+        description=u"Uses a date and time picker (zope.schema.Datetime)",
         required=False,
     )
 
     date_field = schema.Date(
-        title=u'Date field',
-        description=u'Uses a date picker (zope.schema.Date)',
+        title=u"Date field",
+        description=u"Uses a date picker (zope.schema.Date)",
         required=False,
     )
 
     time_field = schema.Time(
-        title=u'Time field',
-        description=u'zope.schema.Time',
+        title=u"Time field",
+        description=u"zope.schema.Time",
         required=False,
-        )
+    )
 
     timedelta_field = schema.Timedelta(
-        title=u'Timedelta field',
-        description=u'zope.schema.Timedelta',
+        title=u"Timedelta field",
+        description=u"zope.schema.Timedelta",
         required=False,
-        )
+    )
 
     # Relation Fields
     relationchoice_field = RelationChoice(
         title=u"Relationchoice field",
-
-        description=u'z3c.relationfield.schema.RelationChoice',
-        vocabulary='plone.app.vocabularies.Catalog',
+        description=u"z3c.relationfield.schema.RelationChoice",
+        vocabulary="plone.app.vocabularies.Catalog",
         required=False,
     )
 
     relationlist_field = RelationList(
-        title=u'Relationlist Field',
-        description=u'z3c.relationfield.schema.RelationList',
+        title=u"Relationlist Field",
+        description=u"z3c.relationfield.schema.RelationList",
         default=[],
-        value_type=RelationChoice(vocabulary='plone.app.vocabularies.Catalog'),
+        value_type=RelationChoice(vocabulary="plone.app.vocabularies.Catalog"),
         required=False,
         missing_value=[],
     )
 
     relationchoice_field_constrained = RelationChoice(
-        title=u'Relationchoice field (only allows Documents)',
-        description=u'z3c.relationfield.schema.RelationChoice',
-        vocabulary='plone.app.vocabularies.Catalog',
+        title=u"Relationchoice field (only allows Documents)",
+        description=u"z3c.relationfield.schema.RelationChoice",
+        vocabulary="plone.app.vocabularies.Catalog",
         required=False,
     )
     directives.widget(
         "relationchoice_field_constrained",
         RelatedItemsFieldWidget,
-        pattern_options={'selectableTypes': ['Document']},
+        pattern_options={"selectableTypes": ["Document"]},
     )
 
     relationlist_field_constrained = RelationList(
-        title=u'Relationlist Field (only allows Documents and Events)',
-        description=u'z3c.relationfield.schema.RelationList',
+        title=u"Relationlist Field (only allows Documents and Events)",
+        description=u"z3c.relationfield.schema.RelationList",
         default=[],
-        value_type=RelationChoice(vocabulary='plone.app.vocabularies.Catalog'),
+        value_type=RelationChoice(vocabulary="plone.app.vocabularies.Catalog"),
         required=False,
         missing_value=[],
     )
     directives.widget(
-        'relationlist_field_constrained',
+        "relationlist_field_constrained",
         RelatedItemsFieldWidget,
-        pattern_options={'selectableTypes': ['Document', 'Event']},
+        pattern_options={"selectableTypes": ["Document", "Event"]},
     )
 
-
     relationlist_field_search_mode = RelationList(
-        title=u'Relationlist Field in Search Mode (constrained to published Documents and Events)',
-        description=u'z3c.relationfield.schema.RelationList',
+        title=u"Relationlist Field in Search Mode (constrained to published Documents and Events)",
+        description=u"z3c.relationfield.schema.RelationList",
         default=[],
         value_type=RelationChoice(
             source=CatalogSource(
-                portal_type=['Document', 'Event'], review_state='published'
+                portal_type=["Document", "Event"], review_state="published"
             )
         ),
         required=False,
         missing_value=[],
     )
     directives.widget(
-        'relationlist_field_search_mode',
+        "relationlist_field_search_mode",
         RelatedItemsFieldWidget,
         pattern_options={
-            'baseCriteria': [  # This is a optimization that limits the catalog-query
+            "baseCriteria": [  # This is a optimization that limits the catalog-query
                 {
-                    'i': 'portal_type',
-                    'o': 'plone.app.querystring.operation.selection.any',
-                    'v': ['Document', 'Event'],
+                    "i": "portal_type",
+                    "o": "plone.app.querystring.operation.selection.any",
+                    "v": ["Document", "Event"],
                 },
                 {
-                    'i': 'review_state',
-                    'o': 'plone.app.querystring.operation.selection.any',
-                    'v': 'published',
+                    "i": "review_state",
+                    "o": "plone.app.querystring.operation.selection.any",
+                    "v": "published",
                 },
             ],
-            'mode': 'search',
+            "mode": "search",
         },
     )
-
 
     # From here on we use other widgets than the default RelatedItemsFieldWidget
 
     # This one also works in Volto!
     # All other options use the default ObjectWidget in Volto so far.
     relationchoice_field_select = RelationChoice(
-        title=u'RelationChoice with Select Widget',
+        title=u"RelationChoice with Select Widget",
         vocabulary=StaticCatalogVocabulary(
             {
-                'portal_type': ['Document', 'Event'],
-                'review_state': 'published',
+                "portal_type": ["Document", "Event"],
+                "review_state": "published",
             }
         ),
         required=False,
     )
     directives.widget(
-        'relationchoice_field_select',
+        "relationchoice_field_select",
         SelectFieldWidget,
     )
 
     relationchoice_field_radio = RelationChoice(
-        title=u'RelationChoice with Radio Widget (and customized title-template)',
+        title=u"RelationChoice with Radio Widget (and customized title-template)",
         vocabulary=StaticCatalogVocabulary(
             {
-                'portal_type': ['Document', 'Event'],
-                'review_state': 'published',
+                "portal_type": ["Document", "Event"],
+                "review_state": "published",
             },
-            title_template='{brain.Title}',
+            title_template="{brain.Title}",
         ),  # Set a custom vocabulary item title
         required=False,
     )
     directives.widget(
-        'relationchoice_field_radio',
+        "relationchoice_field_radio",
         RadioFieldWidget,
     )
 
     relationlist_field_select = RelationList(
-        title=u'RelationList with select widget with items from a named vocabulary',
+        title=u"RelationList with select widget with items from a named vocabulary",
         value_type=RelationChoice(
-            vocabulary='example.vocabularies.documents',
+            vocabulary="example.vocabularies.documents",
         ),
         required=False,
     )
     directives.widget(
-        'relationlist_field_select',
+        "relationlist_field_select",
         SelectFieldWidget,
         pattern_options={
-            'closeOnSelect': False,  # Select2 option to leave dropdown open for multiple selection
+            "closeOnSelect": False,  # Select2 option to leave dropdown open for multiple selection
         },
     )
 
     relationlist_field_checkbox = RelationList(
-        title=u'RelationList with Checkboxes',
+        title=u"RelationList with Checkboxes",
         value_type=RelationChoice(
-            vocabulary='example.vocabularies.documents',
+            vocabulary="example.vocabularies.documents",
         ),
         required=False,
     )
     directives.widget(
-        'relationlist_field_checkbox',
+        "relationlist_field_checkbox",
         CheckBoxFieldWidget,
     )
 
     relationchoice_field_ajax_select = RelationChoice(
-        title=u'Relationchoice Field with AJAXSelect',
-        description=u'z3c.relationfield.schema.RelationChoice',
+        title=u"Relationchoice Field with AJAXSelect",
+        description=u"z3c.relationfield.schema.RelationChoice",
         vocabulary=StaticCatalogVocabulary(
             {
-                'portal_type': ['Document', 'Event'],
+                "portal_type": ["Document", "Event"],
             }
         ),
         required=False,
     )
     directives.widget(
-        'relationchoice_field_ajax_select',
+        "relationchoice_field_ajax_select",
         AjaxSelectFieldWidget,
         vocabulary=StaticCatalogVocabulary(
             {
-                'portal_type': ['Document', 'Event'],
+                "portal_type": ["Document", "Event"],
             }
         ),
         pattern_options={  # Options for Select2
-            'minimumInputLength': 2,  # - Don't query until at least two characters have been typed
-            'ajax': {'quietMillis': 500},  # - Wait 500ms after typing to make query
+            "minimumInputLength": 2,  # - Don't query until at least two characters have been typed
+            "ajax": {"quietMillis": 500},  # - Wait 500ms after typing to make query
         },
     )
 
     relationlist_field_ajax_select = RelationList(
-        title=u'Relationlist Field with AJAXSelect',
-        description=u'z3c.relationfield.schema.RelationList',
+        title=u"Relationlist Field with AJAXSelect",
+        description=u"z3c.relationfield.schema.RelationList",
         value_type=RelationChoice(
             vocabulary=StaticCatalogVocabulary(
                 {
-                    'portal_type': ['Document', 'Event'],
-                    'review_state': 'published',
+                    "portal_type": ["Document", "Event"],
+                    "review_state": "published",
                 }
             )
         ),
         required=False,
     )
     directives.widget(
-        'relationlist_field_ajax_select',
+        "relationlist_field_ajax_select",
         AjaxSelectFieldWidget,
         vocabulary=StaticCatalogVocabulary(
             {
-                'portal_type': ['Document', 'Event', 'Folder'],
+                "portal_type": ["Document", "Event", "Folder"],
             },
-            title_template='{brain.Type}: {brain.Title} at {path}',
+            title_template="{brain.Type}: {brain.Title} at {path}",
         ),  # Custom item rendering
         pattern_options={  # Options for Select2
-            'minimumInputLength': 2,  # - Don't query until at least two characters have been typed
-            'ajax': {'quietMillis': 500},  # - Wait 500ms after typing to make query
+            "minimumInputLength": 2,  # - Don't query until at least two characters have been typed
+            "ajax": {"quietMillis": 500},  # - Wait 500ms after typing to make query
         },
     )
 
@@ -537,182 +532,181 @@ class IExample(model.Schema):
     # as a string in a the field instead of a RelationValue.
     # A good way to use these is in combination with a index that allows you to query these connenctions.
     uuid_choice_field = schema.Choice(
-        title=u'Choice field with RelatedItems widget storing uuids',
-        description=u'schema.Choice',
-        vocabulary='plone.app.vocabularies.Catalog',
+        title=u"Choice field with RelatedItems widget storing uuids",
+        description=u"schema.Choice",
+        vocabulary="plone.app.vocabularies.Catalog",
         required=False,
     )
-    directives.widget('uuid_choice_field', RelatedItemsFieldWidget)
+    directives.widget("uuid_choice_field", RelatedItemsFieldWidget)
 
     uuid_list_field = schema.List(
-        title=u'List Field with RelatedItems widget storing uuids',
-        description=u'schema.List',
+        title=u"List Field with RelatedItems widget storing uuids",
+        description=u"schema.List",
         default=[],
-        value_type=schema.Choice(vocabulary='plone.app.vocabularies.Catalog'),
+        value_type=schema.Choice(vocabulary="plone.app.vocabularies.Catalog"),
         required=False,
         missing_value=[],
     )
-    directives.widget('uuid_list_field', RelatedItemsFieldWidget)
+    directives.widget("uuid_list_field", RelatedItemsFieldWidget)
 
     uuid_choice_field_constrained = schema.Choice(
-        title=u'Choice field with RelatedItems widget storing uuids (only allows Documents)',
-        description=u'schema.Choice',
-        vocabulary='plone.app.vocabularies.Catalog',
+        title=u"Choice field with RelatedItems widget storing uuids (only allows Documents)",
+        description=u"schema.Choice",
+        vocabulary="plone.app.vocabularies.Catalog",
         required=False,
     )
     directives.widget(
-        'uuid_choice_field_constrained',
+        "uuid_choice_field_constrained",
         RelatedItemsFieldWidget,
-        pattern_options={'selectableTypes': ['Document']},
+        pattern_options={"selectableTypes": ["Document"]},
     )
 
     uuid_list_field_constrained = schema.List(
-        title=u'List Field with RelatedItems widget storing uuids (only allows Documents and Events)',
-        description=u'schema.List',
+        title=u"List Field with RelatedItems widget storing uuids (only allows Documents and Events)",
+        description=u"schema.List",
         default=[],
-        value_type=schema.Choice(vocabulary='plone.app.vocabularies.Catalog'),
+        value_type=schema.Choice(vocabulary="plone.app.vocabularies.Catalog"),
         required=False,
         missing_value=[],
     )
     directives.widget(
-        'uuid_list_field_constrained',
+        "uuid_list_field_constrained",
         RelatedItemsFieldWidget,
-        pattern_options={'selectableTypes': ['Document', 'Folder']},
+        pattern_options={"selectableTypes": ["Document", "Folder"]},
     )
 
     uuid_list_field_search_mode = schema.List(
-        title=u'List Field with RelatedItems widget in Search Mode storing uuids',
-        description=u'schema.List',
+        title=u"List Field with RelatedItems widget in Search Mode storing uuids",
+        description=u"schema.List",
         default=[],
         value_type=schema.Choice(
             source=CatalogSource(
-                portal_type=['Document', 'Event'], review_state='published'
+                portal_type=["Document", "Event"], review_state="published"
             )
         ),
         required=False,
         missing_value=[],
     )
     directives.widget(
-        'uuid_list_field_search_mode',
+        "uuid_list_field_search_mode",
         RelatedItemsFieldWidget,
         pattern_options={
             "selectableTypes": ["Document", "Folder"],
-            "basePath": make_relation_root_path,
-            'basePath': '',  # Start the search at the portal root
-            'mode': 'search',
+            "basePath": "",  # Start the search at the portal root
+            "mode": "search",
         },
     )
 
     # From here on we use other widgets than the default RelatedItemsFieldWidget
 
     uuid_choice_field_select = schema.Choice(
-        title=u'UUID Choice with select widget storing uuids',
+        title=u"UUID Choice with select widget storing uuids",
         vocabulary=StaticCatalogVocabulary(
             {
-                'portal_type': ['Document', 'Event'],
-                'review_state': 'published',
+                "portal_type": ["Document", "Event"],
+                "review_state": "published",
             }
         ),
         required=False,
     )
     directives.widget(
-        'uuid_choice_field_select',
+        "uuid_choice_field_select",
         SelectFieldWidget,
     )
 
     uuid_choice_field_radio = schema.Choice(
-        title=u'RelationChoice with Radio widget storing uuids',
+        title=u"RelationChoice with Radio widget storing uuids",
         vocabulary=StaticCatalogVocabulary(
             {
-                'portal_type': ['Document', 'Event'],
-                'review_state': 'published',
+                "portal_type": ["Document", "Event"],
+                "review_state": "published",
             },
-            title_template='{brain.Title}',
+            title_template="{brain.Title}",
         ),  # Set a custom vocabulary item title
         required=False,
     )
     directives.widget(
-        'uuid_choice_field_radio',
+        "uuid_choice_field_radio",
         RadioFieldWidget,
     )
 
     uuid_list_field_select = schema.List(
-        title=u'RelationList with select widget with items from a named vocabulary storing uuids',
+        title=u"RelationList with select widget with items from a named vocabulary storing uuids",
         value_type=schema.Choice(
-            vocabulary='example.vocabularies.documents',
+            vocabulary="example.vocabularies.documents",
         ),
         required=False,
     )
     directives.widget(
-        'uuid_list_field_select',
+        "uuid_list_field_select",
         SelectFieldWidget,
         pattern_options={
-            'closeOnSelect': False,  # Select2 option to leave dropdown open for multiple selection
+            "closeOnSelect": False,  # Select2 option to leave dropdown open for multiple selection
         },
     )
 
     uuid_list_field_checkbox = schema.List(
-        title=u'RelationList with Checkboxes storing uuids',
+        title=u"RelationList with Checkboxes storing uuids",
         value_type=schema.Choice(
-            vocabulary='example.vocabularies.documents',
+            vocabulary="example.vocabularies.documents",
         ),
         required=False,
     )
     directives.widget(
-        'uuid_list_field_checkbox',
+        "uuid_list_field_checkbox",
         CheckBoxFieldWidget,
     )
 
     uuid_choice_field_ajax_select = schema.Choice(
-        title=u'Relationchoice Field with AJAXSelect storing uuids',
-        description=u'z3c.relationfield.schema.RelationChoice',
+        title=u"Relationchoice Field with AJAXSelect storing uuids",
+        description=u"z3c.relationfield.schema.RelationChoice",
         vocabulary=StaticCatalogVocabulary(
             {
-                'portal_type': ['Document', 'Event'],
+                "portal_type": ["Document", "Event"],
             }
         ),
         required=False,
     )
     directives.widget(
-        'uuid_choice_field_ajax_select',
+        "uuid_choice_field_ajax_select",
         AjaxSelectFieldWidget,
         vocabulary=StaticCatalogVocabulary(
             {
-                'portal_type': ['Document', 'Event'],
+                "portal_type": ["Document", "Event"],
             }
         ),
         pattern_options={  # Options for Select2
-            'minimumInputLength': 2,  # - Don't query until at least two characters have been typed
-            'ajax': {'quietMillis': 500},  # - Wait 500ms after typing to make query
+            "minimumInputLength": 2,  # - Don't query until at least two characters have been typed
+            "ajax": {"quietMillis": 500},  # - Wait 500ms after typing to make query
         },
     )
 
     uuid_list_field_ajax_select = schema.List(
-        title=u'Relationlist Field with AJAXSelect storing uuids',
-        description=u'z3c.relationfield.schema.RelationList',
+        title=u"Relationlist Field with AJAXSelect storing uuids",
+        description=u"z3c.relationfield.schema.RelationList",
         value_type=schema.Choice(
             vocabulary=StaticCatalogVocabulary(
                 {
-                    'portal_type': ['Document', 'Event'],
-                    'review_state': 'published',
+                    "portal_type": ["Document", "Event"],
+                    "review_state": "published",
                 }
             )
         ),
         required=False,
     )
     directives.widget(
-        'uuid_list_field_ajax_select',
+        "uuid_list_field_ajax_select",
         AjaxSelectFieldWidget,
         vocabulary=StaticCatalogVocabulary(
             {
-                'portal_type': ['Document', 'Event'],
+                "portal_type": ["Document", "Event"],
             },
-            title_template='{brain.Type}: {brain.Title} at {path}',
+            title_template="{brain.Type}: {brain.Title} at {path}",
         ),  # Custom item rendering
         pattern_options={  # Options for Select2
-            'minimumInputLength': 2,  # - Don't query until at least two characters have been typed
-            'ajax': {'quietMillis': 500},  # - Wait 500ms after typing to make query
-            'closeOnSelect': False,  # - Leave dropdown open for multiple selection
+            "minimumInputLength": 2,  # - Don't query until at least two characters have been typed
+            "ajax": {"quietMillis": 500},  # - Wait 500ms after typing to make query
+            "closeOnSelect": False,  # - Leave dropdown open for multiple selection
         },
     )
 
@@ -737,53 +731,53 @@ class IExample(model.Schema):
     )
 
     uri_field = schema.URI(
-        title=u'URI field',
-        description=u'A simple input field for a URLs (zope.schema.URI)',
+        title=u"URI field",
+        description=u"A simple input field for a URLs (zope.schema.URI)",
         required=False,
-        )
+    )
 
     richtext_field = RichText(
-        title=u'RichText field',
-        description=u'This uses a richtext editor. (plone.app.textfield.RichText)',
+        title=u"RichText field",
+        description=u"This uses a richtext editor. (plone.app.textfield.RichText)",
         max_length=2000,
         required=False,
-        )
+    )
 
     sourcetext_field = schema.SourceText(
-        title=u'SourceText field',
+        title=u"SourceText field",
         description=u"zope.schema.SourceText",
         required=False,
-        )
+    )
 
     ascii_field = schema.ASCII(
-        title=u'ASCII field',
+        title=u"ASCII field",
         description=u"zope.schema.ASCII",
         required=False,
-        )
+    )
 
     bytesline_field = schema.BytesLine(
-        title=u'BytesLine field',
+        title=u"BytesLine field",
         description=u"zope.schema.BytesLine",
         required=False,
-        )
+    )
 
     asciiline_field = schema.ASCIILine(
-        title=u'ASCIILine field',
+        title=u"ASCIILine field",
         description=u"zope.schema.ASCIILine",
         required=False,
-        )
+    )
 
     pythonidentifier_field = schema.PythonIdentifier(
-        title=u'PythonIdentifier field',
+        title=u"PythonIdentifier field",
         description=u"zope.schema.PythonIdentifier",
         required=False,
-        )
+    )
 
     dottedname_field = schema.DottedName(
-        title=u'DottedName field',
+        title=u"DottedName field",
         description=u"zope.schema.DottedName",
         required=False,
-        )
+    )
 
     # dict_field = schema.Dict(
     #     title=u'Dict field',
@@ -858,13 +852,13 @@ class IExample(model.Schema):
     #     )
 
     datagrid_field = schema.List(
-        title=u'Datagrid field',
+        title=u"Datagrid field",
         description=u"schema.List",
-        value_type=DictRow(title=u'Table', schema=IMyRowSchema),
+        value_type=DictRow(title=u"Table", schema=IMyRowSchema),
         default=[],
         required=False,
     )
-    directives.widget('datagrid_field', DataGridFieldFactory)
+    directives.widget("datagrid_field", DataGridFieldFactory)
 
 
 @implementer(IExample)

--- a/src/example/contenttype/testing.py
+++ b/src/example/contenttype/testing.py
@@ -21,8 +21,10 @@ class ExampleContenttypeLayer(PloneSandboxLayer):
         # The z3c.autoinclude feature is disabled in the Plone fixture base
         # layer.
         import plone.restapi
+        import collective.z3cform.datagridfield
 
         self.loadZCML(package=plone.restapi)
+        self.loadZCML(package=collective.z3cform.datagridfield)
         self.loadZCML(package=example.contenttype)
 
     def setUpPloneSite(self, portal):

--- a/src/example/contenttype/vocabularies.py
+++ b/src/example/contenttype/vocabularies.py
@@ -7,7 +7,7 @@ from zope.schema.interfaces import IVocabularyFactory
 def DocumentVocabularyFactory(context=None):
     return StaticCatalogVocabulary(
         {
-            'portal_type': ['Document', 'News Item'],
-            'sort_on': 'sortable_title',
+            "portal_type": ["Document", "News Item"],
+            "sort_on": "sortable_title",
         }
     )

--- a/src/example/contenttype/vocabularies.py
+++ b/src/example/contenttype/vocabularies.py
@@ -1,0 +1,13 @@
+from plone.app.vocabularies.catalog import StaticCatalogVocabulary
+from zope.interface import provider
+from zope.schema.interfaces import IVocabularyFactory
+
+
+@provider(IVocabularyFactory)
+def DocumentVocabularyFactory(context=None):
+    return StaticCatalogVocabulary(
+        {
+            'portal_type': ['Document', 'News Item'],
+            'sort_on': 'sortable_title',
+        }
+    )

--- a/test_plone52.cfg
+++ b/test_plone52.cfg
@@ -9,3 +9,6 @@ update-versions-file = test_plone52.cfg
 
 [versions]
 plone.testing = 7.0.1
+
+# Added by buildout at 2021-08-17 09:10:11.489423
+createcoverage = 1.5


### PR DESCRIPTION
replaces https://github.com/collective/example.contenttype/pull/1 due to crazy merge-conflicts