### PR TITLE
Correct invalid python_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     ],
@@ -47,7 +50,6 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    python_requires="==2.7, >=3.6",
     install_requires=[
         "setuptools",
         # -*- Extra requirements: -*-

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     install_requires=[
         "setuptools",
         # -*- Extra requirements: -*-


### PR DESCRIPTION
Installation with pip fails cause ',' is interpreted as AND.
https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires